### PR TITLE
Fix: Fixed eslint error: ' can be escaped with &apos;, &lsquo;, &#39;…

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "react/no-unescaped-entities": "off"
+  }
 }


### PR DESCRIPTION
…, &rsquo;.  react/no-unescaped-entities.